### PR TITLE
Compare synapses

### DIFF
--- a/cnmodel/cells/__init__.py
+++ b/cnmodel/cells/__init__.py
@@ -19,6 +19,7 @@ from .pyramidal import *
 from .sgc import *
 from .octopus import *
 from .tuberculoventral import *
+from .mso import *
 from .hh import *
 
 from .cell import Cell

--- a/cnmodel/cells/bushy.py
+++ b/cnmodel/cells/bushy.py
@@ -109,7 +109,7 @@ class BushyRothman(Bushy):
     """
 
     def __init__(self, morphology=None, decorator=None, nach=None,
-                 ttx=False, species='guineapig', modelType=None, debug=False):
+                 ttx=False, species='guineapig', modelType=None, debug=False, temperature=None):
         """
         Create a bushy cell, using the default parameters for guinea pig from
         R&M2003, as a type II cell.
@@ -171,7 +171,7 @@ class BushyRothman(Bushy):
         self.status = {'soma': True, 'axon': False, 'dendrites': False, 'pumps': False, 'hillock': False, 
                        'initialsegment': False, 'myelinatedaxon': False, 'unmyelinatedaxon': False,
                        'na': nach, 'species': species, 'modelType': modelType, 'ttx': ttx, 'name': 'Bushy',
-                       'morphology': morphology, 'decorator': decorator, 'temperature': None}
+                       'morphology': morphology, 'decorator': decorator, 'temperature': temperature}
 
         self.spike_threshold = -40
         self.vrange = [-70., -55.]  # set a default vrange for searching for rmp

--- a/cnmodel/cells/bushy.py
+++ b/cnmodel/cells/bushy.py
@@ -1,7 +1,7 @@
 from neuron import h
 
 from .cell import Cell
-# from .. import synapses
+from .. import synapses
 from ..util import nstomho
 from ..util import Params
 import numpy as np
@@ -81,6 +81,24 @@ class Bushy(Cell):
                             (terminal.cell.type, self.type))
         else:
             raise ValueError("Unsupported psd type %s" % psd_type)
+
+    def make_terminal(self, post_cell, term_type, **kwds):
+        if term_type == 'simple':
+            return synapses.SimpleTerminal(self.soma, post_cell, **kwds)
+
+        elif term_type == 'multisite':
+            if post_cell.type == 'mso':
+                nzones = data.get('bushy_synapse', species=self.species,
+                        post_type=post_cell.type, field='n_rsites')
+                delay = 0
+            else:
+                raise NotImplementedError("No knowledge as to how to connect Bushy cell to cell type %s" %
+                                        type(post_cell))
+            pre_sec = self.soma
+            return synapses.StochasticTerminal(pre_sec, post_cell, nzones=nzones, 
+                                            delay=delay, **kwds)
+        else:
+            raise ValueError("Unsupported terminal type %s" % term_type)
 
 
 class BushyRothman(Bushy):

--- a/cnmodel/cells/mso.py
+++ b/cnmodel/cells/mso.py
@@ -83,7 +83,7 @@ class MSORothman(MSO):
     """
 
     def __init__(self, morphology=None, decorator=None, nach=None,
-                 ttx=False, species='guineapig', modelType=None, debug=False):
+                 ttx=False, species='guineapig', modelType=None, debug=False, temperature=None):
         """
         Create a MSO cell, using the default parameters for guinea pig from
         R&M2003, as a type II cell.
@@ -145,7 +145,7 @@ class MSORothman(MSO):
         self.status = {'soma': True, 'axon': False, 'dendrites': False, 'pumps': False, 'hillock': False, 
                        'initialsegment': False, 'myelinatedaxon': False, 'unmyelinatedaxon': False,
                        'na': nach, 'species': species, 'modelType': modelType, 'ttx': ttx, 'name': 'MSO',
-                       'morphology': morphology, 'decorator': decorator, 'temperature': None}
+                       'morphology': morphology, 'decorator': decorator, 'temperature': temperature}
 
         self.spike_threshold = -40
         self.vrange = [-70., -55.]  # set a default vrange for searching for rmp

--- a/cnmodel/cells/mso.py
+++ b/cnmodel/cells/mso.py
@@ -1,0 +1,618 @@
+from neuron import h
+
+from .cell import Cell
+# from .. import synapses
+from ..util import nstomho
+from ..util import Params
+import numpy as np
+from .. import data
+
+__all__ = ['Bushy', 'BushyRothman']
+
+
+class Bushy(Cell):
+    
+    type = 'bushy'
+
+    @classmethod
+    def create(cls, model='RM03', **kwds):
+        if model == 'RM03':
+            return BushyRothman(**kwds)
+        else:
+            raise ValueError ('Bushy model %s is unknown', model)
+
+    def make_psd(self, terminal, psd_type, **kwds):
+        """
+        Connect a presynaptic terminal to one post section at the specified location, with the fraction
+        of the "standard" conductance determined by gbar.
+        The default condition is designed to pass the unit test (loc=0.5)
+        
+        Parameters
+        ----------
+        terminal : Presynaptic terminal (NEURON object)
+        
+        psd_type : either simple or multisite PSD for bushy cell
+        
+        kwds: dictionary of options. 
+            Two are currently handled:
+            postsite : expect a list consisting of [sectionno, location (float)]
+            AMPAScale : float to scale the ampa currents
+        
+        """
+        if 'postsite' in kwds:  # use a defined location instead of the default (soma(0.5)
+            postsite = kwds['postsite']
+            loc = postsite[1]  # where on the section?
+            uname = 'sections[%d]' % postsite[0]  # make a name to look up the neuron section object
+            post_sec = self.hr.get_section(uname)  # Tell us where to put the synapse.
+        else:
+            loc = 0.5
+            post_sec = self.soma
+        
+        if psd_type == 'simple':
+            return self.make_exp2_psd(post_sec, terminal, loc=loc)
+        elif psd_type == 'multisite':
+            if terminal.cell.type == 'sgc':
+                # Max conductances for the glu mechanisms are calibrated by 
+                # running `synapses/tests/test_psd.py`. The test should fail
+                # if these values are incorrect
+                self.AMPAR_gmax = data.get('sgc_synapse', species=self.species,
+                        post_type=self.type, field='AMPAR_gmax')*1e3
+                self.NMDAR_gmax = data.get('sgc_synapse', species=self.species,
+                        post_type=self.type, field='NMDAR_gmax')*1e3
+                self.Pr = data.get('sgc_synapse', species=self.species,
+                        post_type=self.type, field='Pr')
+                # adjust gmax to correct for initial Pr
+                self.AMPAR_gmax = self.AMPAR_gmax/self.Pr
+                self.NMDAR_gmax = self.NMDAR_gmax/self.Pr
+#               original values (now in synapses.py):
+#                self.AMPA_gmax = 3.314707700918133*1e3  # factor of 1e3 scales to pS (.mod mechanisms) from nS.
+#                self.NMDA_gmax = 0.4531929783503451*1e3
+                if 'AMPAScale' in kwds:  # normally, this should not be done!
+                    self.AMPAR_gmax = self.AMPAR_gmax * kwds['AMPAScale']  # allow scaling of AMPA conductances
+                if 'NMDAScale' in kwds:
+                    self.NMDAR_gmax = self.NMDAR_gmax * kwds['NMDAScale']  # and NMDA... 
+                return self.make_glu_psd(post_sec, terminal, self.AMPAR_gmax, self.NMDAR_gmax, loc=loc)
+            elif terminal.cell.type == 'dstellate':
+                return self.make_gly_psd(post_sec, terminal, type='glyslow', loc=loc)
+            elif terminal.cell.type == 'tuberculoventral':
+                return self.make_gly_psd(post_sec, terminal, type='glyslow', loc=loc)
+            else:
+                raise TypeError("Cannot make PSD for %s => %s" % 
+                            (terminal.cell.type, self.type))
+        else:
+            raise ValueError("Unsupported psd type %s" % psd_type)
+
+
+class BushyRothman(Bushy):
+    """
+    VCN bushy cell models.
+        Rothman and Manis, 2003abc (Type II, Type II-I)
+        Xie and Manis, 2013
+    """
+
+    def __init__(self, morphology=None, decorator=None, nach=None,
+                 ttx=False, species='guineapig', modelType=None, debug=False):
+        """
+        Create a bushy cell, using the default parameters for guinea pig from
+        R&M2003, as a type II cell.
+        Additional modifications to the cell can be made by calling methods below.
+        
+        Parameters
+        ----------
+        morphology : string (default: None)
+            Name of a .hoc file representing the morphology. This file is used to constructe
+            an electrotonic (cable) model. 
+            If None (default), then a "point" (really, single cylinder) model is made, exactly according to RM03.
+            
+        decorator : Python function (default: None)
+            decorator is a function that "decorates" the morphology with ion channels according
+            to a set of rules.
+            If None, a default set of channels is inserted into the first soma section, and the
+            rest of the structure is "bare".
+        
+        nach : string (default: None)
+            nach selects the type of sodium channel that will be used in the model. A channel mechanism
+            by that name must exist. The default channel is set to 'nacn' (R&M03)
+        
+        temperature : float (default: 22)
+            temperature to run the cell at. 
+                 
+        ttx : Boolean (default: False)
+            If ttx is True, then the sodium channel conductance is set to 0 everywhere in the cell.
+            This flag duplicates the effects of tetrodotoxin in the model. Currently, the flag is not implemented.
+        
+        species: string (default 'guineapig')
+            species defines the pattern of ion channel densities that will be inserted, according to 
+            prior measurements in various species. Note that
+            if a decorator function is specified, this argument is ignored as the decorator will
+            specify the channel density.
+            
+        modelType: string (default: None)
+            modelType specifies the subtype of the cell model that will be used (e.g., "II", "II-I", etc).
+            modelType is passed to the decorator, or to species_scaling to adjust point (single cylinder) models.
+            
+        debug: boolean (default: False)
+            When True, there will be multiple printouts of progress and parameters.
+            
+        Returns
+        -------
+            Nothing
+                 
+        """
+        super(BushyRothman, self).__init__()
+        self.i_test_range={'pulse': (-1, 1, 0.05)}  # note that this gets reset with decorator according to channels
+                                                    # Changing the default values will cause the unit tests to fail!
+        if modelType == None:
+            modelType = 'II'
+        if nach == None and species == 'guineapig':
+            nach = 'na'
+        if nach == None and species == 'mouse':
+            nach = 'na'
+            self.i_test_range={'pulse': (-1, 1.2, 0.05)}
+        
+        self.status = {'soma': True, 'axon': False, 'dendrites': False, 'pumps': False, 'hillock': False, 
+                       'initialsegment': False, 'myelinatedaxon': False, 'unmyelinatedaxon': False,
+                       'na': nach, 'species': species, 'modelType': modelType, 'ttx': ttx, 'name': 'Bushy',
+                       'morphology': morphology, 'decorator': decorator, 'temperature': None}
+
+        self.spike_threshold = -40
+        self.vrange = [-70., -55.]  # set a default vrange for searching for rmp
+        print 'model type, species: ', modelType, species, nach
+        if morphology is None:
+            """
+            instantiate a basic soma-only ("point") model
+            """
+            print "<< Bushy model: Creating point cell >>"
+            soma = h.Section(name="Bushy_Soma_%x" % id(self))  # one compartment of about 29000 um2
+            soma.nseg = 1
+            self.add_section(soma, 'soma')
+        else:
+            """
+            instantiate a structured model with the morphology as specified by 
+            the morphology file
+            """
+            print "<< Bushy model: Creating cell with morphology from %s >>" % morphology
+            self.set_morphology(morphology_file=morphology)
+
+        # decorate the morphology with ion channels
+        if decorator is None:   # basic model, only on the soma
+            self.mechanisms = ['klt', 'kht', 'ihvcn', 'leak', nach]
+            for mech in self.mechanisms:
+                self.soma.insert(mech)
+            self.soma.ena = self.e_na
+            self.soma.ek = self.e_k
+            self.soma().ihvcn.eh = self.e_h
+            self.soma().leak.erev = self.e_leak
+            self.c_m = 0.9
+            self.species_scaling(silent=True, species=species, modelType=modelType)  # set the default type II cell parameters
+        else:  # decorate according to a defined set of rules on all cell compartments
+            self.decorate()
+#        print 'Mechanisms inserted: ', self.mechanisms
+        self.get_mechs(self.soma)
+#        self.cell_initialize(vrange=self.vrange)  # no need to do this just yet.
+        if debug:
+            print "   << Created cell >>"
+
+    def get_cellpars(self, dataset, species='guineapig', celltype='II'):
+        cellcap = data.get(dataset, species=species, cell_type=celltype,
+            field='soma_Cap')
+        chtype = data.get(dataset, species=species, cell_type=celltype,
+            field='soma_na_type')
+        pars = Params(cap=cellcap, natype=chtype)
+        for g in ['soma_kht_gbar', 'soma_klt_gbar', 'soma_ih_gbar', 'soma_leak_gbar']:
+            pars.additem(g,  data.get(dataset, species=species, cell_type=celltype,
+            field=g))
+        return pars
+
+    def species_scaling(self, species='guineapig', modelType='II', silent=True):
+        """
+        Adjust all of the conductances and the cell size according to the species requested.
+        This scaling should be used ONLY for point models, as no other compartments
+        are scaled.
+        
+        This scaling routine also sets the temperature for the model to a default value. Some models
+        can be run at multiple temperatures, and so a default from one of the temperatures is used.
+        The calling cell.set_temperature(newtemp) will change the conductances and reinitialize
+        the cell to the new temperature settings.
+        
+        Parameters
+        ----------
+        species : string (default: 'guineapig')
+            name of the species to use for scaling the conductances in the base point model
+            Must be one of mouse, cat, guineapig
+        
+        modelType: string (default: 'II')
+            definition of model type from RM03 models, type II or type II-I
+        
+        silent : boolean (default: True)
+            run silently (True) or verbosely (False)
+        
+        """
+        #print '\nSpecies scaling: %s   %s' % (species, type)
+        knownspecies = ['mouse', 'guineapig', 'cat']
+        
+        soma = self.soma
+        if modelType == 'II':
+            celltype = 'bushy-II'
+        elif modelType == 'II-I':
+            celltype = 'bushy-II-I'
+        elif modelType == 'I-II':
+            celltype = 'bushy-I-II'
+        else:
+            raise ValueError('model type not recognized')
+
+        if species == 'mouse':
+            # use conductance levels determined from Cao et al.,  J. Neurophys., 2007. as 
+            # model description in Xie and Manis 2013. Note that
+            # conductances were not scaled for temperature (rates were)
+            # so here we reset the default Q10's for conductance (g) to 1.0
+            if celltype not in ['bushy-II', 'bushy-II-I']:
+                raise ValueError('\nCell type %s is not implemented for mouse bushy cells' % celltype)
+            print '  Setting conductances for mouse bushy cell (%s), Xie and Manis, 2013' % celltype
+            dataset = 'XM13_channels'
+            self.vrange = [-68., -55.]  # set a default vrange for searching for rmp
+            self.i_test_range = {'pulse': (-1., 1., 0.05)}
+            self._valid_temperatures = (34., )
+            if self.status['temperature'] is None:
+                self.status['temperature'] = 34. 
+
+            pars = self.get_cellpars(dataset, species=species, celltype=celltype)
+            self.set_soma_size_from_Cm(pars.cap)
+            self.status['na'] = pars.natype
+            self.adjust_na_chans(soma, sf=1.0)
+            soma().kht.gbar = nstomho(pars.soma_kht_gbar, self.somaarea)
+            soma().klt.gbar = nstomho(pars.soma_klt_gbar, self.somaarea)
+            soma().ihvcn.gbar = nstomho(pars.soma_ih_gbar, self.somaarea)
+            soma().leak.gbar = nstomho(pars.soma_leak_gbar, self.somaarea)
+            self.axonsf = 0.57
+            
+        elif species == 'guineapig':
+            print '  Setting conductances for guinea pig %s bushy cell, Rothman and Manis, 2003' % modelType
+            self._valid_temperatures = (22., 38.)
+            if self.status['temperature'] is None:
+                self.status['temperature'] = 22. 
+            self.i_test_range = {'pulse': (-0.4, 0.4, 0.02)}
+            sf = 1.0
+            if self.status['temperature'] == 38.:  # adjust for 2003 model conductance levels at 38
+                sf = 2  # Q10 of 2, 22->38C. (p3106, R&M2003c)
+                # note that kinetics are scaled in the mod file.
+            dataset = 'RM03_channels'
+            pars = self.get_cellpars(dataset, species=species, celltype=celltype)
+            self.set_soma_size_from_Cm(pars.cap)
+            self.status['na'] = pars.natype
+            self.adjust_na_chans(soma, sf=sf)
+            soma().kht.gbar = nstomho(pars.soma_kht_gbar, self.somaarea)
+            soma().klt.gbar = nstomho(pars.soma_klt_gbar, self.somaarea)
+            soma().ihvcn.gbar = nstomho(pars.soma_ih_gbar, self.somaarea)
+            soma().leak.gbar = nstomho(pars.soma_leak_gbar, self.somaarea)
+
+            self.axonsf = 0.57
+            
+        else:
+            errmsg = 'Species "%s" or model type "%s" is not recognized for Bushy cells.' %  (species, modelType)
+            errmsg += '\n  Valid species are: \n'
+            for s in knownspecies:
+                errmsg += '    %s\n' % s
+            errmsg += '-'*40
+            raise ValueError(errmsg)
+
+        self.status['species'] = species
+        self.status['modelType'] = modelType
+        self.check_temperature()
+#        self.cell_initialize(vrange=self.vrange)  # no need to do this just yet.
+        if not silent:
+           print ' set cell as: ', species
+           print ' with Vm rest = %6.3f' % self.vm0
+
+    def channel_manager(self, modelType='RM03'):
+        """
+        This routine defines channel density maps and distance map patterns
+        for each type of compartment in the cell. The maps
+        are used by the ChannelDecorator class (specifically, its private
+        \_biophys function) to decorate the cell membrane.
+        These settings are only used if the decorator is called; otherwise
+        for point cells, the species_scaling routine defines the channel
+        densities.
+        
+        Parameters
+        ----------
+        modelType : string (default: 'RM03')
+            A string that defines the type of the model. Currently, 3 types are implemented:
+            RM03: Rothman and Manis, 2003 somatic densities for guinea pig
+            XM13: Xie and Manis, 2013, somatic densities for mouse
+            mGBC: experimental mouse globular bushy cell with dendrites, axon, hillock and initial segment, for
+            use with fully reconstructed neurons.
+        
+        Returns
+        -------
+        Nothing
+        
+        Notes
+        -----
+        This routine defines the following variables for the class:
+        
+            * conductances (gBar)
+            * a channelMap (dictonary of channel densities in defined anatomical compartments)
+            * a current injection range for IV's (used for testing)
+            * a distance map, which defines how each conductance in a selected compartment
+              changes with distance from the soma. The current implementation includes both
+              linear and exponential gradients,
+              the minimum conductance at the end of the gradient, and the space constant or
+              slope for the gradient.
+        
+        """
+        
+        self.c_m = 1E-6  # default in units of F/cm^2
+        if modelType == 'RM03':
+            #
+            # Create a model based on the Rothman and Manis 2003 conductance set from guinea pig
+            # 
+            self.c_m = 0.9E-6  # default in units of F/cm^2
+            totcap = 12.0E-12  # in units of F, from Rothman and Manis, 2003.
+            refarea = totcap / self.c_m  # area is in cm^2
+            # bushy Rothman-Manis, guinea pig type II
+            # model gave cell conductance in nS, but we want S/cm^2 for NEURON
+            # so conversion is 1e-9*nS = uS, and refarea is already in cm2
+            self._valid_temperatures = (22., 38.)
+            sf = 1.0
+            if self.status['temperature'] == None:
+                self.status['temperature'] = 22.
+            if self.status['temperature'] == 38:
+                sf = 3.03
+            self.gBar = Params(nabar=sf*1000.0E-9/refarea,
+                               khtbar=sf*150.0E-9/refarea,
+                               kltbar=sf*200.0E-9/refarea,
+                               ihbar=sf*20.0E-9/refarea,
+                               leakbar=sf*2.0E-9/refarea,
+            )
+            print 'RM03 gbar:\n', self.gBar.show()
+            
+            self.channelMap = {
+                'axon': {'nacn': self.gBar.nabar, 'klt': self.gBar.kltbar, 'kht': self.gBar.khtbar, 'ihvcn': 0.,
+                         'leak': self.gBar.leakbar / 2.},
+                'hillock': {'nacn': self.gBar.nabar, 'klt': self.gBar.kltbar, 'kht': self.gBar.khtbar, 'ihvcn': 0.,
+                            'leak': self.gBar.leakbar, },
+                'initseg': {'nacn': self.gBar.nabar, 'klt': self.gBar.kltbar, 'kht': self.gBar.khtbar,
+                            'ihvcn': self.gBar.ihbar / 2., 'leak': self.gBar.leakbar, },
+                'soma': {'nacn': self.gBar.nabar, 'klt': self.gBar.kltbar, 'kht': self.gBar.khtbar,
+                         'ihvcn': self.gBar.ihbar, 'leak': self.gBar.leakbar, },
+                'dend': {'nacn': self.gBar.nabar, 'klt': self.gBar.kltbar * 0.5, 'kht': self.gBar.khtbar * 0.5,
+                         'ihvcn': self.gBar.ihbar / 3., 'leak': self.gBar.leakbar * 0.5, },
+                'apic': {'nacn': self.gBar.nabar, 'klt': self.gBar.kltbar * 0.2, 'kht': self.gBar.khtbar * 0.2,
+                         'ihvcn': self.gBar.ihbar / 4., 'leak': self.gBar.leakbar * 0.2, },
+            }
+#            self.irange = np.linspace(-1., 1., 21)
+            self.distMap = {'dend': {'klt': {'gradient': 'linear', 'gminf': 0., 'lambda': 100.},
+                                     'kht': {'gradient': 'linear', 'gminf': 0., 'lambda': 100.},
+                                     'nacn': {'gradient': 'exp', 'gminf': 0., 'lambda': 100.}}, # linear with distance, gminf (factor) is multiplied by gbar
+                            'apic': {'klt': {'gradient': 'linear', 'gminf': 0., 'lambda': 100.},
+                                     'kht': {'gradient': 'linear', 'gminf': 0., 'lambda': 100.},
+                                     'nacn': {'gradient': 'exp', 'gminf': 0., 'lambda': 100.}}, # gradients are: flat, linear, exponential
+                            }
+
+        elif modelType == 'XM13':
+            #
+            # Create a model for a mouse bushy cell from Xie and Manis, 2013
+            # based on Cao and Oertel mouse conductance values
+            # and Rothman and Manis kinetics.
+            self.c_m = 0.9E-6  # default in units of F/cm^2
+            totcap = 26.0E-12 # uF/cm2 
+            refarea = totcap  / self.c_m  # see above for units
+            self._valid_temperatures = (34., )
+            if self.status['temperature'] == None:
+                self.status['temperature'] = 34.
+            self.gBar = Params(nabar=1000.E-9/refarea,
+                               khtbar=58.0E-9/refarea,
+                               kltbar=80.0E-9/refarea,  # note doubled here... 
+                               ihbar=30.0E-9/refarea,
+                               leakbar=2.0E-9/refarea,  # was 0.5
+            )
+            print 'XM13 gbar:\n', self.gBar.show()
+            self.channelMap = {
+                'axon': {'nav11': self.gBar.nabar*1, 'klt': self.gBar.kltbar * 1.0, 'kht': self.gBar.khtbar, 'ihvcn': 0.,
+                         'leak': self.gBar.leakbar * 0.25},
+                'hillock': {'nav11': self.gBar.nabar*2, 'klt': self.gBar.kltbar, 'kht': self.gBar.khtbar*2.0, 'ihvcn': 0.,
+                            'leak': self.gBar.leakbar, },
+                'initseg': {'nav11': self.gBar.nabar*3.0, 'klt': self.gBar.kltbar*1, 'kht': self.gBar.khtbar*2,
+                            'ihvcn': self.gBar.ihbar * 0.5, 'leak': self.gBar.leakbar, },
+                'soma': {'nav11': self.gBar.nabar*0.5, 'klt': self.gBar.kltbar, 'kht': self.gBar.khtbar,
+                         'ihvcn': self.gBar.ihbar, 'leak': self.gBar.leakbar, },
+                'dend': {'nav11': self.gBar.nabar * 0.25, 'klt': self.gBar.kltbar *0.5, 'kht': self.gBar.khtbar *0.5,
+                         'ihvcn': self.gBar.ihbar *0.5, 'leak': self.gBar.leakbar * 0.5, },
+                'dendrite': {'nav11': self.gBar.nabar * 0.25, 'klt': self.gBar.kltbar *0.5, 'kht': self.gBar.khtbar *0.5,
+                         'ihvcn': self.gBar.ihbar *0.5, 'leak': self.gBar.leakbar * 0.5, },
+                'apic': {'nav11': self.gBar.nabar * 0.25, 'klt': self.gBar.kltbar * 0.25, 'kht': self.gBar.khtbar * 0.25,
+                         'ihvcn': self.gBar.ihbar *0.25, 'leak': self.gBar.leakbar * 0.25, },
+            }
+            self.irange = np.linspace(-2, 2, 7)
+            self.distMap = {'dend': {'klt': {'gradient': 'exp', 'gminf': 0., 'lambda': 50.},
+                                     'kht': {'gradient': 'exp', 'gminf': 0., 'lambda': 50.},
+                                     'nav11': {'gradient': 'exp', 'gminf': 0., 'lambda': 50.}}, # linear with distance, gminf (factor) is multiplied by gbar
+                            'dendrite': {'klt': {'gradient': 'linear', 'gminf': 0., 'lambda': 100.},
+                                     'kht': {'gradient': 'linear', 'gminf': 0., 'lambda': 100.},
+                                     'nav11': {'gradient': 'linear', 'gminf': 0., 'lambda': 100.}}, # linear with distance, gminf (factor) is multiplied by gbar
+                            'apic': {'klt': {'gradient': 'linear', 'gminf': 0., 'lambda': 100.},
+                                     'kht': {'gradient': 'linear', 'gminf': 0., 'lambda': 100.},
+                                     'nav11': {'gradient': 'exp', 'gminf': 0., 'lambda': 200.}}, # gradients are: flat, linear, exponential
+                            }
+
+                            
+        elif modelType == 'mGBC':
+            # bushy from Xie and Manis, 2013, based on Cao and Oertel mouse conductances,
+            # BUT modified ad hoc for SBEM reconstructions.
+            totcap = 26.0E-12 # uF/cm2 
+            refarea = totcap  / self.c_m  # see above for units
+            # original:
+            # self.gBar = Params(nabar=500.E-9/refarea,
+            #                    khtbar=58.0E-9/refarea,
+            #                    kltbar=80.0E-9/refarea,  # note doubled here...
+            #                    ihbar=0.25*30.0E-9/refarea,
+            #                    leakbar=0.05*2.0E-9/refarea,  # was 0.5
+            # )
+            self._valid_temperatures = (34.,)
+            if self.status['temperature'] == None:
+                self.status['temperature'] = 34.
+            self.gBar = Params(nabar=1600.E-9/refarea,
+                               khtbar=58.0E-9/refarea,
+                               kltbar=40.0E-9/refarea,  # note doubled here... 
+                               ihbar=0.25*30.0E-9/refarea,
+                               leakbar=0.02*2.0E-9/refarea,  # was 0.5
+            )
+            print 'mGBC gbar:\n', self.gBar.show()
+            sodiumch = 'jsrna'
+            self.channelMap = {
+                'axon': {sodiumch: self.gBar.nabar*1., 'klt': self.gBar.kltbar * 1.0, 'kht': self.gBar.khtbar, 'ihvcn': 0.,
+                         'leak': self.gBar.leakbar * 0.25},
+                'unmyelinatedaxon': {sodiumch: self.gBar.nabar*3.0, 'klt': self.gBar.kltbar * 2.0,
+                         'kht': self.gBar.khtbar*3.0, 'ihvcn': 0.,
+                         'leak': self.gBar.leakbar * 0.25},
+                'myelinatedaxon': {sodiumch: self.gBar.nabar*0, 'klt': self.gBar.kltbar * 1e-2,
+                         'kht': self.gBar.khtbar*1e-2, 'ihvcn': 0.,
+                         'leak': self.gBar.leakbar * 0.25*1e-3},
+                'hillock': {sodiumch: self.gBar.nabar*4.0, 'klt': self.gBar.kltbar*1.0, 'kht': self.gBar.khtbar*3.0,
+                             'ihvcn': 0., 'leak': self.gBar.leakbar, },
+                'initseg': {sodiumch: self.gBar.nabar*3.0, 'klt': self.gBar.kltbar*2, 'kht': self.gBar.khtbar*2,
+                            'ihvcn': self.gBar.ihbar * 0.5, 'leak': self.gBar.leakbar, },
+                'soma': {sodiumch: self.gBar.nabar*0.65, 'klt': self.gBar.kltbar, 'kht': self.gBar.khtbar*1.5,
+                         'ihvcn': self.gBar.ihbar, 'leak': self.gBar.leakbar, },
+                'dend': {sodiumch: self.gBar.nabar * 0.2, 'klt': self.gBar.kltbar *1, 'kht': self.gBar.khtbar *1,
+                         'ihvcn': self.gBar.ihbar *0.5, 'leak': self.gBar.leakbar * 0.5, },
+                'dendrite': {sodiumch: self.gBar.nabar * 0.2, 'klt': self.gBar.kltbar *1, 'kht': self.gBar.khtbar *1,
+                         'ihvcn': self.gBar.ihbar *0.5, 'leak': self.gBar.leakbar * 0.5, },
+                'apic': {sodiumch: self.gBar.nabar * 0.25, 'klt': self.gBar.kltbar * 0.25, 'kht': self.gBar.khtbar * 0.25,
+                         'ihvcn': self.gBar.ihbar *0.25, 'leak': self.gBar.leakbar * 0.25, },
+            }
+            self.irange = np.arange(-1.5, 2.1, 0.25 )
+            self.distMap = {'dend': {'klt': {'gradient': 'linear', 'gminf': 0., 'lambda': 100.},
+                                     'kht': {'gradient': 'linear', 'gminf': 0., 'lambda': 100.},
+                                     sodiumch: {'gradient': 'linear', 'gminf': 0., 'lambda': 100.}}, # linear with distance, gminf (factor) is multiplied by gbar
+                            'dendrite': {'klt': {'gradient': 'linear', 'gminf': 0., 'lambda': 20.},
+                                      'kht': {'gradient': 'linear', 'gminf': 0., 'lambda': 20.},
+                                      sodiumch: {'gradient': 'linear', 'gminf': 0., 'lambda': 20.}}, # linear with distance, gminf (factor) is multiplied by gbar
+                            'apic': {'klt': {'gradient': 'linear', 'gminf': 0., 'lambda': 100.},
+                                     'kht': {'gradient': 'linear', 'gminf': 0., 'lambda': 100.},
+                                     sodiumch: {'gradient': 'exp', 'gminf': 0., 'lambda': 200.}}, # gradients are: flat, linear, exponential
+                            }
+        else:
+            raise ValueError('model type %s is not implemented' % modelType)
+        self.check_temperature()
+
+    def adjust_na_chans(self, soma, sf=1.0, gbar=1000., debug=False):
+        """
+        adjust the sodium channel conductance
+        
+        Parameters
+        ----------
+        soma : neuron section object
+            A soma object whose sodium channel complement will have its 
+            conductances adjusted depending on the channel type
+        
+        gbar : float (default: 1000.)
+            The maximal conductance for the sodium channel
+        
+        debug : boolean (false):
+            Verbose printing
+            
+        Returns
+        -------
+            Nothing :
+        
+        """
+        
+        if self.status['ttx']:
+            gnabar = 0.0
+        else:
+            gnabar = nstomho(gbar, self.somaarea)*sf
+        nach = self.status['na']
+        if nach == 'jsrna':
+            soma().jsrna.gbar = gnabar
+            soma.ena = self.e_na
+            if debug:
+                print 'jsrna gbar: ', soma().jsrna.gbar
+        elif nach == 'nav11':
+            soma().nav11.gbar = gnabar
+            soma.ena = 50 # self.e_na
+#            print('gnabar: ', soma().nav11.gbar, ' vs: 0.0192307692308')
+            soma().nav11.vsna = 4.3
+            if debug:
+                print "bushy using inva11"
+        elif nach in ['na', 'nacn']:
+            soma().na.gbar = gnabar
+            soma.ena = self.e_na
+            if debug:
+                print 'na gbar: ', soma().na.gbar
+        else:
+            raise ValueError('Sodium channel %s is not recognized for Bushy cells', nach)
+
+    def add_axon(self):
+        """
+        Add a default axon from the generic cell class to the bushy cell (see cell class).
+        """
+        Cell.add_axon(self, self.c_m, self.R_a, self.axonsf)
+
+    def add_pumps(self):
+        """
+        Insert mechanisms for potassium ion management, sodium ion management, and a
+        sodium-potassium pump at the soma.
+        """
+        soma = self.soma
+        soma.insert('k_conc')
+
+        ki0_k_ion = 140
+        soma().ki = ki0_k_ion
+        soma().ki0_k_conc = ki0_k_ion
+        soma().beta_k_conc = 0.075
+
+        soma.insert('na_conc')
+        nai0_na_ion = 5
+        soma().nai = nai0_na_ion
+        soma().nai0_na_conc = nai0_na_ion
+        soma().beta_na_conc = 0.075
+
+        soma.insert('nakpump')
+        soma().nakpump.inakmax = 8
+        soma().nao = 145
+        soma().ko = 5
+        soma().nakpump.Nai_inf = 5
+        soma().nakpump.Ki_inf = 140
+        soma().nakpump.ATPi = 5
+        self.status['pumps'] = True
+
+    def add_dendrites(self, debug=False):
+        """
+        Add a simple dendrite to the bushy cell.
+        """
+        if debug:
+            print 'Adding dendrite to Bushy model'
+        section = h.Section
+        maindend = section(cell=self.soma)
+        maindend.connect(self.soma)
+        maindend.nseg = 10
+        maindend.L = 100.0
+        maindend.diam = 2.5
+        maindend.insert('klt')
+        maindend.insert('ihvcn')
+        maindend().klt.gbar = self.soma().klt.gbar / 2.0
+        maindend().ihvcn.gbar = self.soma().ihvcn.gbar / 2.0
+
+        maindend.cm = self.c_m
+        maindend.Ra = self.R_a
+        nsecd = range(0, 5)
+        secdend = []
+        for ibd in nsecd:
+            secdend.append(section(cell=self.soma))
+        for ibd in nsecd:
+            secdend[ibd].connect(maindend)
+            secdend[ibd].diam = 1.0
+            secdend[ibd].L = 15.0
+            secdend[ibd].cm = self.c_m
+            secdend[ibd].Ra = self.R_a
+        self.maindend = maindend
+        self.secdend = secdend
+        self.status['dendrite'] = True
+        if debug:
+            print 'Bushy: added dendrite'
+            h.topology()
+        self.add_section(maindend, 'maindend')
+        self.add_section(secdend, 'secdend')
+

--- a/cnmodel/cells/mso.py
+++ b/cnmodel/cells/mso.py
@@ -12,7 +12,7 @@ __all__ = ['MSO']
 
 class MSO(Cell):
     
-    type = 'MSO'
+    type = 'mso'
 
     @classmethod
     def create(cls, model='RM03', **kwds):
@@ -57,7 +57,7 @@ class MSO(Cell):
                 # if these values are incorrect
                 self.AMPAR_gmax = data.get('bushy_synapse', species=self.species,
                         post_type=self.type, field='AMPAR_gmax')*1e3
-                self.NMDAR_gmax = data.get('bushy_mso_synapse', species=self.species,
+                self.NMDAR_gmax = data.get('bushy_synapse', species=self.species,
                         post_type=self.type, field='NMDAR_gmax')*1e3
                 self.Pr = data.get('bushy_synapse', species=self.species,
                         post_type=self.type, field='Pr')

--- a/cnmodel/data/connectivity.py
+++ b/cnmodel/data/connectivity.py
@@ -55,7 +55,7 @@ pyramidal         0           0           0           0           0            0
 
 """
 
-add_table_data('convergence', row_key='pre_type', col_key='post_type', 
+add_table_data('mouse_convergence', row_key='pre_type', col_key='post_type', 
                species='mouse', data=mouse_convergence)
 
 
@@ -100,7 +100,119 @@ pyramidal         0           0           0           0           0            0
 
 """
 
-add_table_data('convergence_range', row_key='pre_type', col_key='post_type', 
+add_table_data('mouse_convergence_range', row_key='pre_type', col_key='post_type', 
                species='mouse', data=mouse_convergence_range)
+
+#--------------------------------------------------------------------------------------------
+guineapig_convergence = u"""
+
+Convergence defines the average number of presynaptic cells of a particular
+type (rows) that synapse onto a single postsynaptic cell of a particular
+type (columns).
+This connectivity matrix is currently incomplete.
+Note: Bushy and pyramidal cells are known to have no (or very few)
+collaterals within the CN, and so they are not listed as presynaptic cells in
+this table. Octopus cells have collaterals (including in granule cell domains),
+and should be added to this table when more data are available (Golding et al.,
+J. Neurosci. 15: 3138, 1995)
+
+This table is just a guess... using mouse data...
+
+----------------------------------------------------------------------------------------------
+                  bushy       tstellate   dstellate   octopus     pyramidal    tuberculoventral   MSO
+sgc               3.3±0.6 [2] 6.5±1.0 [2] 35±0 [3]    60±0 [2]    48±0 [5]     24±0 [5]           0
+bushy             0           0           0           0           0            0                  6 [8]
+dstellate         7 [1]       20 [1]      3 [1]       0 [4]       15 [5]       15 [5]             0
+tstellate         0 [6]       0 [6]       0 [6]       0 [6]       0 [6]        0 [6]              0
+tuberculoventral  6           6           0           0 [4]       21 [5]       0 [7]              0
+pyramidal         0           0           0           0           0            0                  0
+----------------------------------------------------------------------------------------------
+
+[1] Guesses based on Campagnola & Manis 2014 (using mouse data on guinea pig cells)
+
+[2] Cao, X. & Oertel, D. (2010). Auditory nerve fibers excite targets through
+    synapses that vary in convergence, strength, and short-term plasticity. 
+    Journal of Neurophysiology, 104(5), 2308–20.
+    Xie and Manis (unpublished): max EPSC = 3.4 ± 1.5 nA with ~0.3 nA steps
+    (Cao and Oertel, 2010) = ~11 AN inputs. However neither we nor Cao and Oertel
+    see that many clear steps in the responses, so use lower bound.
+    
+[3] Lower bound based on estimates from unpublished data Xie and Manis (2017)
+    Assumptions: No discernable step sizes when increasing shock intensity 
+    at ANFs in radiate multipolars (dstellate)
+     Measured: 0.034 ± 15 nA sEPSC @ -70 mV
+     Measured: Maximal current from AN stim = 1.2 ± 0.7 nA @ -70 mV
+     Assuming that each AN provides 1 input, then N = ~35
+     
+[4] Octopus cells are devoid of inhibitory input (Golding et al., J. Neurosci., 1995)
+
+[5] Convergence from Hancock and Voigt, Ann. Biomed. Eng. 27, 1999 and Zheng and Voigt,
+    Ann. Biomed. Eng., 34, 2006.  Numbers are based on models for cat and gerbil,
+    respectively. Adjusted to 1/2 to avoid overexciting TV cells in network model.
+
+[6] tstellate cells have collaterals within the CN. It has been proposed that they
+    provide auditory-driven input to the DCN (Oertel and Young, ), and also synapse
+    within the VCN (Oertel, SFN abstract). These parameters may need to be adjusted
+    once the convergence and strength is known.
+
+[7] In the models of Hancock and Voigt (1999) and Zheng and Voigt (2006), the TV cells
+    have no connections with each other. However, Kuo et al. (J. Neurophysiol., 2015)
+    did see connections between pairs of TV cells in the mouse.
+
+[8] Bushy convergence to MSO is a guess
+"""
+
+add_table_data('guineapig_convergence', row_key='pre_type', col_key='post_type', 
+               species='guineapig', data=guineapig_convergence)
+
+
+
+guineapig_convergence_range = u"""
+
+The convergence range table describes, for each type of connection from 
+presynaptic (rows) to postsynaptic (columns), the variance in frequency of
+presynaptic cells relative to the postsynaptic cell.
+
+All values are expressed as the sigma for a lognormal distribution scaled to
+the CF of the postsynaptic cell. 
+
+*** This table is just a guess - using data from mouse... ****
+
+-------------------------------------------------------------------------------------------------------
+                  bushy       tstellate   dstellate   octopus     pyramidal    tuberculoventral   MSO
+sgc               0.05 [1]    0.1 [1]     0.4 [1]     0.5 [5]     0.1 [1]      0.1 [1]            0
+bushy             0           0           0           0           0            0                  0.05 [6]
+dstellate         0.208 [2]   0.347 [2]   0.5 [1]     0           0.2 [1]      0.2 [1]            0
+tstellate         0.1 [4]     0.1 [4]     0           0           0            0                  0
+tuberculoventral  0.069 [3]   0.111 [3]   0           0           0.15 [1]     0                  0
+pyramidal         0           0           0           0           0            0                  0
+--------------------------------------------------------------------------------------------------------
+
+[1] Guess based on axonal / dendritic morphology.
+
+[2] Calculated from Campagnola & Manis 2014 fig. 7C (Using mouse data on guinea pig cells)
+    Distribution widths are given in stdev(octaves), so we multiply by ln(2) to
+    get the sigma for a lognormal distribution.
+        DS->Bushy:     ln(2) * 0.3 = 0.208
+        DS->TStellate: ln(2) * 0.5 = 0.347
+
+[3] Calculated from Campagnola & Manis 2014 fig. 9C (Using mouse data on guinea pig cells)
+    Distribution widths are given in stdev(octaves), so we multiply by ln(2) to
+    get the sigma for a lognormal distribution.
+        TV->Bushy:     ln(2) * 0.10 = 0.069
+        TV->TStellate: ln(2) * 0.16 = 0.111
+
+[4] Guess based on very limited information in Campagnola & Manis 2014 fig. 12
+
+[5] Octopus cells get a wide range of ANF input (but weak on a per input basis)
+    For example, see McGinley et al., 2012 or Spencer et al., 2012.
+
+[6] MSO convergence from bushy cells is a guess.
+
+"""
+
+add_table_data('guineapig_convergence_range', row_key='pre_type', col_key='post_type', 
+               species='guineapig', data=guineapig_convergence_range)
+
 
 

--- a/cnmodel/data/connectivity.py
+++ b/cnmodel/data/connectivity.py
@@ -119,9 +119,9 @@ J. Neurosci. 15: 3138, 1995)
 This table is just a guess... using mouse data...
 
 ----------------------------------------------------------------------------------------------
-                  bushy       tstellate   dstellate   octopus     pyramidal    tuberculoventral   MSO
+                  bushy       tstellate   dstellate   octopus     pyramidal    tuberculoventral   mso
 sgc               3.3±0.6 [2] 6.5±1.0 [2] 35±0 [3]    60±0 [2]    48±0 [5]     24±0 [5]           0
-bushy             0           0           0           0           0            0                  6 [8]
+bushy             0           0           0           0           0            0                  12 [8]
 dstellate         7 [1]       20 [1]      3 [1]       0 [4]       15 [5]       15 [5]             0
 tstellate         0 [6]       0 [6]       0 [6]       0 [6]       0 [6]        0 [6]              0
 tuberculoventral  6           6           0           0 [4]       21 [5]       0 [7]              0
@@ -179,7 +179,7 @@ the CF of the postsynaptic cell.
 *** This table is just a guess - using data from mouse... ****
 
 -------------------------------------------------------------------------------------------------------
-                  bushy       tstellate   dstellate   octopus     pyramidal    tuberculoventral   MSO
+                  bushy       tstellate   dstellate   octopus     pyramidal    tuberculoventral   mso
 sgc               0.05 [1]    0.1 [1]     0.4 [1]     0.5 [5]     0.1 [1]      0.1 [1]            0
 bushy             0           0           0           0           0            0                  0.05 [6]
 dstellate         0.208 [2]   0.347 [2]   0.5 [1]     0           0.2 [1]      0.2 [1]            0

--- a/cnmodel/data/ionchannels.py
+++ b/cnmodel/data/ionchannels.py
@@ -316,4 +316,36 @@ soma_e_na           50.   [1]     50.   [1]
 
 """)
 
+add_table_data('RM03_MSO_channels', row_key='field', col_key='cell_type', 
+               species='guineapig', data=u"""
+
+This table describes the ion channel densities
+for a putative MSO neoron based on the original Rothman Manis 2003 model.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+                    MSO-II   
+                             
+MSO_name            II       
+soma_na_gbar        1000. [1]
+soma_kht_gbar       150.0 [1]
+soma_klt_gbar       200.0 [1]
+soma_ka_gbar        0.0   [1]
+soma_ih_gbar        20.0  [1]
+soma_leak_gbar      2.0   [1]
+soma_leak_erev      -65   [1]
+soma_na_type        nacn  [1]
+soma_ih_type        ihvcn [1]
+soma_Cap            12.0  [1]
+soma_e_k            -84   [1]
+soma_e_na           50.   [1]
+soma_ih_eh          -43   [1]
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+[1] This MSO neuron model is basied on Rothman and Manis, 2003 bushy cell, type II
+    Age "adult", Temperature=22C
+    Units are nS.
+
+
+""")
 

--- a/cnmodel/data/synapses.py
+++ b/cnmodel/data/synapses.py
@@ -251,3 +251,45 @@ XMax         0.733 [1]    0.731 [1]        0.731 [1]     0.731 [2]         0.731
 # TV conductance onto TV cells: 1.8 ns SD 2.3 nS.
 #
 
+add_table_data('bushy_synapse', row_key='field', col_key='post_type', 
+               species='mouse', data=u"""
+
+AMPA_gmax and NMDA_gmax are the estimated average peak conductances (in nS) 
+resulting from an action potential in a single presynaptic terminal under 
+conditions that minimize the effects of short-term plasticity.
+AMPA_gmax are from values measured at -65 mV (or -70mV), and represent SINGLE TERMINAL 
+conductances
+AMPAR_gmax are the individual synapse postsynaptic conductance
+NMDA_gmax values are taken as the fraction of the current that is NMDAR dependent
+at +40 mV (see below)
+
+n_rsites is the number of release sites per terminal.
+
+-----------------------------------------------------------------------------------------------------------------------------------
+             MSO           
+                          
+AMPA_gmax    21.05±15.4 [1]
+AMPAR_gmax   4.6516398 [2]
+NMDA_gmax    0 [3]  
+NMDAR_gmax   0 [3]
+EPSC_cv      0.12 [4]      
+Pr           1.000 [5]    
+n_rsites     5 [6]         
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+[1] Taken from the bushy cell model.
+    Units are nS.
+    
+[2] See note [10] for the SGC-bushy synapse
+
+[3] Assume no NMDA receptors at this synapse
+
+[4] See SGC-bushy synapse
+
+[5] Just to scale with the multisite synapse model
+
+[6] This is a guess.
+
+""")
+

--- a/cnmodel/data/synapses.py
+++ b/cnmodel/data/synapses.py
@@ -131,16 +131,16 @@ These parameters were selected to fit the model output to known EPSC shapes.
 PA is a polyamine block parameter ued in the AMPAR mechanism (concentration in micromolar).
 
 ------------------------------------------------------------------------------------------------
-             bushy              tstellate        dstellate        pyramidal    octopus         tuberculoventral
-                                                                                                               
-Ro1          107.85 [4]         39.25 [4]        39.25 [7]        39.25 [4]    107.85 [5]      39.25 [7]
-Ro2          0.6193 [4]         4.40 [4]         4.40 [7]         4.40 [4]     0.6193 [5]      4.40 [7] 
-Rc1          3.678 [4]          0.667 [4]        0.667 [7]        0.667 [4]    3.678 [5]       0.667 [7]
-Rc2          0.3212 [4]         0.237 [4]        0.237 [7]        0.237 [4]    0.3212 [5]      0.237 [7]
-tau_g        0.10 [4]           0.25 [4]         0.25 [7]         0.25 [4]     0.10 [5]        0.25 [4]   
-amp_g        0.770 [4]          1.56625 [4]      1.56625 [7]      1.56625 [4]  0.770 [5]       1.56625 [4]
-                                                                                                           
-PA           45 [12]            0.1 [12]         0.1 [7]          0.1 [12]     45 [5]          0.1 [7]
+             bushy              tstellate        dstellate        pyramidal    octopus         tuberculoventral       mso     
+                                                                                                                                
+Ro1          107.85 [4]         39.25 [4]        39.25 [7]        39.25 [4]    107.85 [5]      39.25 [7]              107.85 [4]
+Ro2          0.6193 [4]         4.40 [4]         4.40 [7]         4.40 [4]     0.6193 [5]      4.40 [7]               0.6193 [4]
+Rc1          3.678 [4]          0.667 [4]        0.667 [7]        0.667 [4]    3.678 [5]       0.667 [7]              3.678 [4] 
+Rc2          0.3212 [4]         0.237 [4]        0.237 [7]        0.237 [4]    0.3212 [5]      0.237 [7]              0.3212 [4]
+tau_g        0.10 [4]           0.25 [4]         0.25 [7]         0.25 [4]     0.10 [5]        0.25 [4]               0.10 [4]  
+amp_g        0.770 [4]          1.56625 [4]      1.56625 [7]      1.56625 [4]  0.770 [5]       1.56625 [4]            0.770 [4] 
+                                                                                                                                
+PA           45 [12]            0.1 [12]         0.1 [7]          0.1 [12]     45 [5]          0.1 [7]                45 [12]   
 
 ------------------------------------------------------------------------------------------------
 
@@ -155,7 +155,6 @@ PA           45 [12]            0.1 [12]         0.1 [7]          0.1 [12]     4
 [12] Wang & Manis (unpublished)
 
 """)
-
 
 
 add_table_data('sgc_epsp_kinetics', row_key='field', col_key='post_type', 
@@ -177,7 +176,6 @@ F            0.984 [11]    0.917 [11]                                     0.984 
 [13] Copied from bushy cells; no direct data
 
 """)
-
 
 
 add_table_data('sgc_release_dynamics', row_key='field', col_key='post_type', 
@@ -266,7 +264,7 @@ at +40 mV (see below)
 n_rsites is the number of release sites per terminal.
 
 -----------------------------------------------------------------------------------------------------------------------------------
-             MSO           
+             mso           
                           
 AMPA_gmax    21.05±15.4 [1]
 AMPAR_gmax   4.6516398 [2]
@@ -274,11 +272,11 @@ NMDA_gmax    0 [3]
 NMDAR_gmax   0 [3]
 EPSC_cv      0.12 [4]      
 Pr           1.000 [5]    
-n_rsites     5 [6]         
+n_rsites     36 [6]         
 
 -----------------------------------------------------------------------------------------------------------------------------------
 
-[1] Taken from the bushy cell model.
+[1] Taken from the mouse bushy cell model.
     Units are nS.
     
 [2] See note [10] for the SGC-bushy synapse

--- a/cnmodel/protocols/synapse_test.py
+++ b/cnmodel/protocols/synapse_test.py
@@ -6,15 +6,16 @@ from neuron import h
 import cnmodel.util as util
 from .protocol import Protocol
 from .. import cells
-from ..synapses import GluPSD, GlyPSD
+from ..synapses import GluPSD, GlyPSD, Exp2PSD
 from ..util.find_point import find_crossing
+import timeit
 
 class SynapseTest(Protocol):
     def reset(self):
         super(SynapseTest, self).reset()
 
     def run(self, pre_sec, post_sec, n_synapses, temp=34.0, dt=0.025, 
-            vclamp=40.0, iterations=1, tstop=240.0, stim_params=None, **kwds):
+            vclamp=40.0, iterations=1, tstop=240.0, stim_params=None, synapsetype='multisite', **kwds):
         """ 
         Basic synapse test. Connects sections of two cells with *n_synapses*.
         The cells are allowed to negotiate the details of the connecting 
@@ -35,7 +36,7 @@ class SynapseTest(Protocol):
         post_cell = cells.cell_from_section(post_sec)
         synapses = []
         for i in range(n_synapses):
-            synapses.append(pre_cell.connect(post_cell))
+            synapses.append(pre_cell.connect(post_cell, type=synapsetype))
         
         self.synapses = synapses
         self.pre_sec = synapses[0].terminal.section
@@ -87,12 +88,18 @@ class SynapseTest(Protocol):
 
         # create hoc vectors for each parameter we wish to monitor and display
         synapse = synapses[0]
-
         self.all_psd = []
-        for syn in synapses:
-            # collect all PSDs across all synapses
-            self.all_psd.extend(syn.psd.all_psd)
-            
+        if synapses[0].psd.n_psd > 1:
+            for syn in synapses:
+                self.all_psd.extend(syn.psd.all_psd)
+        else:
+            try:
+                syntype = synapses[0].psd.syn.hname()[:-3]
+                self.all_psd.extend(synapses)
+            except:
+                for syn in synapses:
+                    self.all_psd.extend(syn.psd.all_psd)
+        
         #for i, cleft in enumerate(synapse.psd.clefts):
             #self['cleft_xmtr%d' % i] = cleft._ref_CXmtr
             #self['cleft_pre%d' % i] = cleft._ref_pre
@@ -112,12 +119,14 @@ class SynapseTest(Protocol):
         self.currents = {'ampa': [], 'nmda': []}
         self.all_releases = []
         self.all_release_events = []
+        start_time = timeit.default_timer()
         for nrep in xrange(iterations): # could do multiple runs.... 
             self.reset()
             self['v_pre'] = pre_cell.soma(0.5)._ref_v
             self['t'] = h._ref_t
             self['v_soma'] = pre_cell.soma(0.5)._ref_v
-            self['relsite_xmtr'] = synapse.terminal.relsite._ref_XMTR[0]
+            if not isinstance(synapse.psd, Exp2PSD):
+                self['relsite_xmtr'] = synapse.terminal.relsite._ref_XMTR[0]
 
             if isinstance(synapse.psd, GluPSD):
                 # make a synapse monitor for each release zone
@@ -163,9 +172,12 @@ class SynapseTest(Protocol):
                     self['C3'] = psd[0]._ref_C3
                     self['O1'] = psd[0]._ref_O1
                     self['O2'] = psd[0]._ref_O2
+            elif isinstance(synapse.psd, Exp2PSD):
+                self['iPSD'] = self.all_psd[0].psd.syn._ref_i
 
-            for i, s in enumerate(synapses):
-                s.terminal.relsite.rseed = util.random.current_seed() + nrep
+            if not isinstance(synapse.psd, Exp2PSD):
+                for i, s in enumerate(synapses):
+                    s.terminal.relsite.rseed = util.random.current_seed() + nrep
             util.custom_init()
             h.run()
 
@@ -184,12 +196,14 @@ class SynapseTest(Protocol):
                 isoma = np.zeros_like(self['iGLY000'])
                 for k in range(len(self.all_psd)):
                     isoma += self['iGLY%03d'%k]
+            elif isinstance(synapse.psd, Exp2PSD):
+                 isoma = self['iPSD']
             self.isoma.append(isoma)
             self.all_releases.append(self.release_timings())
             self.all_release_events.append(self.release_events())
-            # if nrep > 0:
-            #     assert (np.all(self.isoma[0] != self.isoma[1]))
-#        print np.all(self.isoma[0] == self.isoma[1])
+
+        elapsed = timeit.default_timer() - start_time
+        print 'Elapsed time for %d Repetions: %f' % (iterations, elapsed)
         
     def release_events(self, syn_no=0):
         """
@@ -219,27 +233,29 @@ class SynapseTest(Protocol):
         """
         synapse = self.synapses[syn_no]
         
-        ret = {}
+        ret = {'n_zones': [0], 'n_spikes': [0], 'n_requests': [0], 'n_releases': [0],
+                'tot_requests': 0, 'tot_releases': 0, 'release_p': 0.}
         #
         # Count spikes and releases for each terminal
         #
-        ret['n_zones'] = np.array([syn.terminal.n_rzones for syn in self.synapses])
-        ret['n_spikes'] = np.array([syn.terminal.relsite.nRequests for syn in self.synapses])
-        ret['n_requests'] = ret['n_spikes'] * ret['n_zones']
-        ret['n_releases'] = np.array([syn.terminal.relsite.nReleases for syn in self.synapses])
+        if not isinstance(self.synapses[0].psd, Exp2PSD):
+            ret['n_zones'] = np.array([syn.terminal.n_rzones for syn in self.synapses])
+            ret['n_spikes'] = np.array([syn.terminal.relsite.nRequests for syn in self.synapses])
+            ret['n_requests'] = ret['n_spikes'] * ret['n_zones']
+            ret['n_releases'] = np.array([syn.terminal.relsite.nReleases for syn in self.synapses])
 
-        #
-        # Compute release probability
-        #
-        # total number of release requests
-        ret['tot_requests'] = ret['n_requests'].sum()
-        # total number of actual release events        
-        ret['tot_releases'] = ret['n_releases'].sum() 
-        
-        if ret['tot_requests'] > 0:
-            ret['release_p'] = float(ret['tot_releases']) / ret['tot_requests']
-        else:
-            ret['release_p'] = np.nan
+            #
+            # Compute release probability
+            #
+            # total number of release requests
+            ret['tot_requests'] = ret['n_requests'].sum()
+            # total number of actual release events
+            ret['tot_releases'] = ret['n_releases'].sum()
+
+            if ret['tot_requests'] > 0:
+                ret['release_p'] = float(ret['tot_releases']) / ret['tot_requests']
+            else:
+                ret['release_p'] = np.nan
         
         return ret
 
@@ -249,6 +265,9 @@ class SynapseTest(Protocol):
         and latency of release events. 
         """
         data = []
+        if isinstance(self.synapses[0].psd, Exp2PSD):
+            return data
+
         for j in range(0, len(self.synapses)):
             relsite = self.synapses[j].terminal.relsite
             nev = int(relsite.ev_index)
@@ -310,6 +329,9 @@ class SynapseTest(Protocol):
                 omax = np.abs(self['opGLY%03d'%i]).max()
             
             return {'gly': (glyImax, glyOmax)}
+        
+        elif isinstance(synapse.psd, Exp2PSD):
+            return {'Exp2PSD': (0., 0.)}
 
     def analyze_events(self):
         events = []
@@ -366,7 +388,7 @@ class SynapseTest(Protocol):
             istart = int(tstart / self.dt)   # pulse start index
             tp[i] = tstart - stim['delay']
             iend = istart + pscpts
-            print 'istart: %d iend: %d, len(isoma): %d\n' % (istart, iend, len(self.isoma[runno]))
+            #print 'istart: %d iend: %d, len(isoma): %d\n' % (istart, iend, len(self.isoma[runno]))
             ipsc[i, :] = np.abs(self.isoma[runno][istart:iend])
             psc_pk = minStart + np.argmax(ipsc[i, minStart:-(extend_pts+1)]) # position of the peak
             
@@ -430,8 +452,9 @@ class SynapseTest(Protocol):
         print 'Total release requests: %d' % events['tot_requests']
         print 'Total release events:   %d' % events['tot_releases']
         print 'Release probability: %8.3f' % events['release_p']
-        prel_final = synapse.terminal.relsite.Dn * synapse.terminal.relsite.Fn
-        print 'Final release probability (Dn * Fn): %8.3f' % prel_final
+        if not isinstance(synapse.psd, Exp2PSD):
+            prel_final = synapse.terminal.relsite.Dn * synapse.terminal.relsite.Fn
+            print 'Final release probability (Dn * Fn): %8.3f' % prel_final
 
 
         #
@@ -443,7 +466,7 @@ class SynapseTest(Protocol):
             glyImax, glyOPmax = oprob['gly']
             print 'Max GLYR Open Prob: %f' % (glyOPmax,)
             print 'Max GLYR I: %f' % (glyImax,)
-        else:
+        elif 'ampa' in oprob or 'nmda' in oprob:
             nmImax, nmOPmax = oprob['nmda'].values()
             amImax, amOPmax = oprob['ampa'].values()
             print 'Max NMDAR Open Prob: %f   AMPA Open Prob: %f' % (nmOPmax, amOPmax)
@@ -529,8 +552,7 @@ class SynapseTest(Protocol):
         #
         nst = range(self.stim['NP'])
         analysisWindow = [nst[0:2], nst[-5:]]
-        print analysisWindow
-        print events[eventno]['rise time']
+
         RT_mean2080_early = np.nanmean(events[eventno]['rise time'][analysisWindow[0]])
         RT_mean2080_late = np.nanmean(events[eventno]['rise time'][analysisWindow[1]])
         Lat_mean20_early = np.nanmean(events[eventno]['20% latency'][analysisWindow[0]])
@@ -575,19 +597,20 @@ class SynapseTest(Protocol):
             p7.setYLink(p6)
             self.plots['latency_distribution'] = p7
             self.win.ci.layout.setColumnFixedWidth(1, 200)
+            if not isinstance(self.synapses[0].psd, Exp2PSD):
             
-            rel_events = self.all_releases
-            all_latencies = []
-            for i, trial in enumerate(rel_events):
-                for syn in trial:
-                    p6.plot(syn['time'], syn['latency'], pen=None, symbolBrush=(i, len(rel_events)), 
-                        symbolPen=(i, len(rel_events)), symbolSize=4, symbol='o')
-                    all_latencies.append(syn['latency'])
-            all_latencies = np.concatenate(all_latencies)
-            (hist, binedges) = np.histogram(all_latencies)
-            curve = p7.plot(binedges, hist, stepMode=True, fillBrush=(100, 100, 255, 150), fillLevel=0)
-            curve.rotate(-90)
-            curve.scale(-1, 1)
+                rel_events = self.all_releases
+                all_latencies = []
+                for i, trial in enumerate(rel_events):
+                    for syn in trial:
+                        p6.plot(syn['time'], syn['latency'], pen=None, symbolBrush=(i, len(rel_events)), 
+                            symbolPen=(i, len(rel_events)), symbolSize=4, symbol='o')
+                        all_latencies.append(syn['latency'])
+                all_latencies = np.concatenate(all_latencies)
+                (hist, binedges) = np.histogram(all_latencies)
+                curve = p7.plot(binedges, hist, stepMode=True, fillBrush=(100, 100, 255, 150), fillLevel=0)
+                curve.rotate(-90)
+                curve.scale(-1, 1)
 
         # if probabilityPlot:
         #     self.win.nextRow()

--- a/examples/test_cells.py
+++ b/examples/test_cells.py
@@ -26,7 +26,7 @@ default_durs = [10., 100., 20.]
 cclamp = False
 
 cellinfo = {'types': ['bushy', 'bushycoop', 'tstellate', 'tstellatenav11', 'dstellate', 'dstellateeager', 'sgc',
-                      'cartwheel', 'pyramidal', 'octopus', 'tuberculoventral'],
+                      'cartwheel', 'pyramidal', 'octopus', 'tuberculoventral', 'mso'],
             'morphology': ['point', 'waxon', 'stick'],
             'nav': ['std', 'jsrna', 'nav11', 'nacncoop'],
             'species': ['guineapig', 'cat', 'rat', 'mouse'],
@@ -53,6 +53,7 @@ ccivrange = {'mouse':
             'dstellateeager': {'pulse': [(-0.6, 1.0, 0.025)]},
             'octopus': {'pulse': [(-2., 6., 0.2)]},
             'sgc': {'pulse': [(-0.3, 0.6, 0.02)]},
+            'mso': {'pulse': [(-1, 1.2, 0.05)]},
             },
             'rat':
             {'pyramidal': {'pulse': [(-0.3, 0.3, 0.025), (-0.040, 0.025, 0.005)]}, # 'prepulse': [(-0.25, -0.25, 0.25)]},
@@ -86,7 +87,10 @@ scale = {'bushy': (-1.0, -160., 1.0, -40, 0, 40, 'offset', 5,
         'tuberculoventral': (-1.0, -160., 1.0, -40, 0, 40, 'offset', 5,
             'crossing', [0, -60]),
         'octopus': (-1.0, -160., 1.0, -40, 0, 40, 'offset', 5,
-            'crossing', [0, -60])}
+            'crossing', [0, -60]),
+        'mso': (-1.0, -160., 1.0, -40, 0, 40, 'offset', 5,
+                        'crossing', [0, -60]),
+        }
 
 class Tests():
     """
@@ -202,12 +206,18 @@ class Tests():
                     ttx=args.ttx, debug=debugFlag)
             h.topology()
 
-
         #
         # DCN cartwheel cell tests
         #
         elif args.celltype == 'cartwheel':
             cell = cells.Cartwheel.create(modelType=args.type, ttx=args.ttx, debug=debugFlag)
+
+        #
+        # MSO principal neuron tests
+        #
+        elif args.celltype == 'mso' and args.morphology == 'point':
+            cell = cells.MSO.create(model='RM03', species=args.species, modelType=args.type,
+                ttx=args.ttx, nach=args.nav, debug=debugFlag)    
 
         else:
             raise ValueError ("Cell Type %s and configurations nav=%s or config=%s are not available" %

--- a/examples/test_mso_inputs.py
+++ b/examples/test_mso_inputs.py
@@ -1,0 +1,166 @@
+"""
+Test generating a series of EPSPs in a MSO cell in response to tone pip.
+
+This script:
+
+1. Creates multiple SGCs (base instance has 3), two bushy cells and one mso cell
+2. Connects the a group of sgc cells from one ear to one bushy cell, and the 
+    other sgcs from the other ear to the
+    other bushy cell. The two bushy cells are then connected to the mso neuron.
+3. The SGC cells can be offeset in frequency, and the stimuli can be ear-specific
+    allowing for "binaural beats"
+4. Specifies tone pip inputs to each ear.
+5. Records the bushy and mso cell Vms.
+
+
+The auditory nerve spike train is generated automatically by the DummySGC class
+using the tone pip. For lower-level access to the auditory nerve model, see the
+test_an_model.py and test_sound_stim.py examples.
+
+The AN simulator that is run depends on what is available and how the script is called. 
+python examples/test_sgc_input.py [cochlea | matlab] will try to use the specified
+simulator. If no simulator is specified, it will try to use cochlea or matlab, in
+that order.
+
+"""
+import sys
+import numpy as np
+import pyqtgraph as pg
+from neuron import h
+from cnmodel.protocols import Protocol
+from cnmodel import cells
+from cnmodel.util import sound
+from cnmodel.util import custom_init
+import cnmodel.util.pynrnutilities as PU
+
+class MSOBinauralTest(Protocol):
+    def run(self, temp=34.0, dt=0.025, seed=575982035, simulator=None):
+        ears = {'left': [500., 502, 498], 'right': [500., 502., 498]}
+        
+        self.beatfreq = 0.
+        self.f0 = 500.
+        f0 = {'left': self.f0, 'right': self.f0+self.beatfreq}
+        nsgc = len(ears.keys())
+        sgcCell = {}
+        bushyCell = {}
+        msoCell = {}
+        synapse = {}
+        self.stim = {}
+        self.ears = ears
+        self.stimdur = 1.0
+        self.stimdelay = 0.02
+        self.rundur = self.stimdelay + self.stimdur + 0.02
+
+        for i, ear in enumerate(ears.keys()):
+            nsgc = len(ears[ear])  # how many sgcs are specified for this ear
+            sgcCell[ear] = [cells.DummySGC(cf=ears[ear][k], sr=2) for k in range(nsgc)]
+            bushyCell[ear] = cells.Bushy.create()
+            synapse[ear] = [sgcCell[ear][k].connect(bushyCell[ear]) for k in range(nsgc)]
+            self.stim[ear] = [sound.TonePip(rate=100e3, duration=self.stimdur+0.1, f0=f0[ear], dbspl=80,
+                                  ramp_duration=2.5e-3, pip_duration=self.stimdur, 
+                                  pip_start=[self.stimdelay]) for k in range(nsgc)]
+            for k in range(len(self.stim[ear])):
+                sgcCell[ear][k].set_sound_stim(self.stim[ear][k], seed=seed + i*seed + k, simulator=simulator)
+            self['vm_bu_%s' % ear] = bushyCell[ear].soma(0.5)._ref_v
+            for k in range(30):
+                self['xmtr%d_%s'%(k, ear)] = synapse[ear][0].terminal.relsite._ref_XMTR[k]
+            for k in range(len(synapse[ear])):
+                synapse[ear][k].terminal.relsite.Dep_Flag = False  # turn off depression
+
+        msoCell = cells.MSO.create()  # one target MSO cell
+        msosyn = {}
+        for ear in ears:
+            msosyn[ear] = bushyCell[ear].connect(msoCell)
+        self.sgc_cells = sgcCell
+        self.bushy_cells = bushyCell
+        self.synapses = synapse
+        self.msyns = msosyn
+        self.msoCell = msoCell
+         
+        self['vm_mso'] = self.msoCell.soma(0.5)._ref_v
+        for k, ear in enumerate(ears.keys()):
+            for i in range(30):
+                self['mso_xmtr%d_%s'%(i, ear)] = msosyn[ear].terminal.relsite._ref_XMTR[i]
+            msosyn[ear].terminal.relsite.Dep_Flag = False  # turn off depression
+
+        self['t'] = h._ref_t
+        
+        h.tstop = self.rundur*1e3 # duration of a run
+        h.celsius = temp
+        h.dt = dt
+        
+        custom_init()
+        h.run()
+
+    def show(self):
+        self.win = pg.GraphicsWindow()
+        
+        p5 = self.win.addPlot(title='stim')
+        p5.plot(self.stim['left'][0].time * 1000., self.stim['left'][0].sound)
+
+        p1 = self.win.addPlot(title='Bushy Vm', row=1, col=0)
+        for k, ear in enumerate(self.ears.keys()):
+            p1.plot(self['t'], self['vm_bu_%s' % ear], pen=(k, 15))
+        
+        p2 = self.win.addPlot(title='SGC-BU xmtr left', row=0, col=1)
+        for i in range(30):
+            p2.plot(self['t'], self['xmtr%d_left'%i], pen=(i, 15))
+        p2.setXLink(p1)
+        p2r = self.win.addPlot(title='SGC-BU xmtr right', row=1, col=1)
+        for i in range(30):
+            p2r.plot(self['t'], self['xmtr%d_right'%i], pen=(i, 15))
+        p2r.setXLink(p1)        
+        
+        p3 = self.win.addPlot(title='MSO Vm', row=2, col=0)
+        p3.plot(self['t'], self['vm_mso'])
+        p3.setXLink(p1)
+        
+        p4 = self.win.addPlot(title='BU-MSO xmtr', row=2, col=1)
+        for k, ear in enumerate(self.ears.keys()):
+            for i in range(30):
+                p2.plot(self['t'], self['mso_xmtr%d_%s'%(i, ear)], pen=(i, 15))
+        p4.setXLink(p1)        
+
+        p4 = self.win.addPlot(title='AN spikes', row=3, col=0)
+        ntrain = len(self.sgc_cells['left'])
+        for k in range(ntrain):
+            yr = [k/float(ntrain), (k+0.8)/float(ntrain)]
+            vt = pg.VTickGroup(self.sgc_cells['left'][k]._spiketrain, yrange = yr, pen=(k, 15))
+            p4.addItem(vt)
+        p4.setXLink(p1)
+        p5.setXLink(p1)
+        
+        # phaselocking calculations
+        phasewin = [self.stimdelay + 0.2*self.stimdur, self.stimdelay + self.stimdur]
+        msospk = PU.findspikes(self['t'], self['vm_mso'], -30.)
+
+        spkin = msospk[np.where(msospk > phasewin[0]*1e3)]
+        spikesinwin = spkin[np.where(spkin <= phasewin[1]*1e3)[0]]
+
+        # set freq for VS calculation
+        f0 = self.f0
+        fb = self.beatfreq
+        vs = PU.vector_strength(spikesinwin, f0)
+
+        print 'MSO Vector Strength at %.1f: %7.3f, d=%.2f (us) Rayleigh: %7.3f  p = %.3e  n = %d' % (f0, vs['r'], vs['d']*1e6, vs['R'], vs['p'], vs['n'])
+        if fb > 0:
+            vsb = PU.vector_strength(spikesinwin, fb)
+            print 'MSO Vector Strength to beat at %.1f: %7.3f, d=%.2f (us) Rayleigh: %7.3f  p = %.3e  n = %d' % (fb, vsb['r'], vsb['d']*1e6, vsb['R'], vsb['p'], vsb['n'])
+        (hist, binedges) = np.histogram(vs['ph'])
+        p6 = self.win.addPlot(title='VS', row=3, col=1)
+        p6.plot(binedges, hist, stepMode=True, fillBrush=(100, 100, 255, 150), fillLevel=0)
+        p6.setXRange(0., 2*np.pi)
+        
+        self.win.show()
+
+
+if __name__ == '__main__':
+    simulator = None
+    if len(sys.argv) > 1:
+        simulator=sys.argv[1]
+    prot = MSOBinauralTest()
+    prot.run(simulator=simulator)
+    prot.show()
+
+    if sys.flags.interactive == 0:
+        pg.QtGui.QApplication.exec_()

--- a/examples/test_sgc_input_phaselocking.py
+++ b/examples/test_sgc_input_phaselocking.py
@@ -13,16 +13,16 @@ class SGCInputTestPL(Protocol):
     def set_cell(self, cell='bushy'):
         self.cell = cell
     
-    def run(self, temp=34.0, dt=0.025, seed=575982035, stimulus='tone'):
+    def run(self, temp=34.0, dt=0.025, seed=575982035, stimulus='tone', species='mouse'):
         assert stimulus in ['tone', 'SAM', 'clicks']  # cases available
         if self.cell == 'bushy':
-            postCell = cells.Bushy.create(species='mouse')
+            postCell = cells.Bushy.create(species=species)
         elif self.cell == 'tstellate':
-            postCell = cells.TStellate.create(species='mouse')
+            postCell = cells.TStellate.create(species=species)
         elif self.cell == 'octopus':
-            postCell = cells.Octopus.create(species='mouse')
+            postCell = cells.Octopus.create(species=species)
         elif self.cell == 'dstellate':
-            postCell = cells.DStellate.create(species='mouse')
+            postCell = cells.DStellate.create(species=species)
         else:
             raise ValueError('cell %s is not yet implemented for phaselocking' % self.cell)
         self.post_cell = postCell
@@ -55,7 +55,7 @@ class SGCInputTestPL(Protocol):
                         click_interval=self.click_rate, nclicks=int((self.run_duration-0.01)/self.click_rate),
                         ramp_duration=2.5e-3)
         
-        n_sgc = data.get('convergence', species='mouse', post_type=postCell.type, pre_type='sgc')[0]
+        n_sgc = data.get('%s_convergence' % species, species=species, post_type=postCell.type, pre_type='sgc')[0]
         self.n_sgc = int(np.round(n_sgc))
 
         self.pre_cells = []
@@ -86,7 +86,6 @@ class SGCInputTestPL(Protocol):
 
     def show(self):
         self.win = pg.GraphicsWindow()
-        Fs = self.Fs
         p1 = self.win.addPlot(title='stim', row=0, col=0)
         p1.plot(self.stim.time * 1000, self.stim.sound)
         p1.setXLink(p1)
@@ -136,9 +135,9 @@ class SGCInputTestPL(Protocol):
             print "Clicks: interval %.3f at %3.1f dbSPL, cell CF=%.3f " % (self.click_rate, self.dbspl, self.cf)
         vs = PU.vector_strength(spikesinwin, f0)
         
-        print 'AN Vector Strength: %7.3f, d=%.2f (us) Rayleigh: %7.3f  p = %.3e  n = %d' % (vs['r'], vs['d']*1e6, vs['R'], vs['p'], vs['n'])
+        print 'AN Vector Strength at %.1f: %7.3f, d=%.2f (us) Rayleigh: %7.3f  p = %.3e  n = %d' % (f0, vs['r'], vs['d']*1e6, vs['R'], vs['p'], vs['n'])
         (hist, binedges) = np.histogram(vs['ph'])
-        curve = p6.plot(binedges, hist, stepMode=True, fillBrush=(100, 100, 255, 150), fillLevel=0)
+        p6.plot(binedges, hist, stepMode=True, fillBrush=(100, 100, 255, 150), fillLevel=0)
         p6.setXRange(0., 2*np.pi)
 
         p7 = self.win.addPlot(title='%s phase' % self.cell, row=2, col=1)
@@ -147,7 +146,7 @@ class SGCInputTestPL(Protocol):
         vs = PU.vector_strength(spikesinwin, f0)
         print '%s Vector Strength: %7.3f, d=%.2f (us) Rayleigh: %7.3f  p = %.3e  n = %d' % (self.cell, vs['r'], vs['d']*1e6, vs['R'], vs['p'], vs['n'])
         (hist, binedges) = np.histogram(vs['ph'])
-        curve = p7.plot(binedges, hist, stepMode=True, fillBrush=(100, 100, 255, 150), fillLevel=0)
+        p7.plot(binedges, hist, stepMode=True, fillBrush=(100, 100, 255, 150), fillLevel=0)
         p7.setXRange(0., 2*np.pi)
         p7.setXLink(p6)
 
@@ -155,6 +154,11 @@ class SGCInputTestPL(Protocol):
 
 
 if __name__ == '__main__':
+    if len(sys.argv) > 1 and sys.argv[1] in ['help', '-h', '--help']:
+        print "\nUsage: python test_sgc_input_phaselocking.py\n    celltype [bushy, tstellate, octopus, dstellate] (default: bushy)"
+        print "    stimulus [tone, SAM, clicks] (default: tone)"
+        print "    species [guineapig mouse] (default: guineapig)\n"
+        exit(0)
     if len(sys.argv) > 1:
         cell = sys.argv[1]
     else:
@@ -163,10 +167,14 @@ if __name__ == '__main__':
         stimulus = sys.argv[2]
     else:
         stimulus = 'tone'
+    if len(sys.argv) > 3:
+        species = sys.argv[3]
+    else:
+        species = 'guineapig'
     print 'cell type: ', cell
     prot = SGCInputTestPL()
     prot.set_cell(cell)
-    prot.run(stimulus=stimulus)
+    prot.run(stimulus=stimulus, species=species)
     prot.show()
 
     import sys

--- a/examples/test_synapses.py
+++ b/examples/test_synapses.py
@@ -68,10 +68,12 @@ def runtest():
         niter = 5
     else:
         niter = 20
-    
-
+    syntype = 'multisite'
+    if len(sys.argv) > 3:
+        syntype = sys.argv[3]
+    assert(syntype in ['simple', 'multisite'])
     st = SynapseTest()
-    st.run(preCell.soma, postCell.soma, nTerminals, vclamp=-65., iterations=niter)
+    st.run(preCell.soma, postCell.soma, nTerminals, vclamp=-65., iterations=niter, synapsetype=syntype)
     st.show_result()
     st.plots['VPre'].setYRange(-70., 10.)
     st.plots['EPSC'].setYRange(-2.0, 0.5)


### PR DESCRIPTION
This PR addresses a request by reviewer for testing timing of the multisite synapse versus a simple synapse.
examples/test_synapses takes 3rd argument (synapse type: simple, multisite). 
protocols/synapse_test.py modified so that when simple is selected, some calculations related to the results of the multisite synapse are ignored (no data is available). 
Added timing to the run() routine (to exclude plotting and most of the setup). 
Note: branch was from the mso_cells branch, so includes that set of changes as well....

Result: Exp2PSD synapse runs about 40x faster than the multisite synapse on a 100-site input to a bushy cell. (on my 3GHz machine: multisite ~ 8.95 s; simple ~ 0.22s for 5 repetitions).
