### PR TITLE
cache changes in filelock

### DIFF
--- a/cnmodel/util/filelock.py
+++ b/cnmodel/util/filelock.py
@@ -68,6 +68,13 @@ class FileLock(object):
         start_time = time.time()
         while True:
             try:
+                # create the cache directory if it does not exist (new installations will not have a cache directory)
+                stimdir = os.path.dirname(self.lockfile)
+                cachedir = os.path.dirname(stimdir)
+                if not os.path.isdir(cachedir):  # make sure the cache exists
+                    os.mkdir(cachedir)
+                if not os.path.isdir(stimdir):  # and the specific stimulus dir
+                    os.mkdir(stimdir)
                 self.fd = os.open(self.lockfile, os.O_CREAT|os.O_EXCL|os.O_RDWR)
                 open(self.lockfile, 'w').write(str(os.getpid()))
                 break;


### PR DESCRIPTION
Filelock would fail when either the cache directory or the specific stimulus subdirectory was missing. This patch checks for the existence of the (AN model) cache directory first, and creates it if it is missing. This situation will occur when a clean installation of cnmodel is performed, on the first run requesting the computation and storage of AN spike trains. The stimulus subdirectory is then created as needed beneath the cache directory. 
Verified suitability of this approach in email with Luke Campagnola. This PR is for documentation and the patch will be merged. 