### PR TITLE
allow data tables to be modified (rewritten) without affecting canoni…

### DIFF
--- a/cnmodel/data/__init__.py
+++ b/cnmodel/data/__init__.py
@@ -1,4 +1,4 @@
-from ._db import get, get_source, add_table_data
+from ._db import get, get_source, add_table_data, report_changes
 from . import connectivity
 from . import synapses
 from . import populations

--- a/cnmodel/data/_db.py
+++ b/cnmodel/data/_db.py
@@ -221,7 +221,9 @@ def add_table_data(name, row_key, col_key, data, **kwds):
             kwds[col_key] = col
             oldval = setval(cells[i][j], name, **kwds)
             if oldval is not None and oldval != cells[i][j]:
-                changes.append({'name': name, 'row': row, 'col': col, 'new': cells[i][j], 'old': oldval})
+                key = mk_key(name, **kwds)
+                changes.append({'key': key, 'new': cells[i][j], 'old': oldval, 'name': name})
+                #changes.append({'name': name, 'row': row, 'col': col, 'new': cells[i][j], 'old': oldval})
     return changes
 
 
@@ -230,9 +232,10 @@ def report_changes(changes):
     For changes to data tables, give user a readout
     """
     if len(changes) > 0:
-        print("\nWarning: Data Table '%s' has been modified!" % changes[0]['name'])
+        print("\nWarning: Data Table '%s' (in memory) has been modified!" % changes[0]['name'])
         for ch in changes:
-            print('  >>> Changing %s, %s from default (%s) to %s' % (ch['row'], ch['col'], str(ch['new'][0]), str(ch['old'][0])))
+            # print('  >>> Changing %s, %s from default (%s) to %s' % (ch['row'], ch['col'], str(ch['new'][0]), str(ch['old'][0])))
+            print('  >>> Changing %s, from default (%s) to %s' % (ch['key'], str(ch['old'][0]), str(ch['new'][0])))
 
 
 def parse_sources(lines):


### PR DESCRIPTION
…cal tables

These are the data table modifications:
1. remove exception when attempting overwrite of a table.
2. If the table exists, then when values are set, keep track of the changes (add_table_data returns a list of the changes)
3. add routine to print out the changes. 

This does not affect the default behavior of cnmodel, but does allow the use of alternate data tables (for example, for connectivity or synaptic function) or on-the-fly changes to a table value for exploration of the parameter space.  